### PR TITLE
Remove support for requests<=2.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup
 import sys
 
 if sys.version_info >= (3,):
-	install_requires = ['PyJWT>=1,<3','requests>=2,<3']
+	install_requires = ['PyJWT>=1,<3', 'requests>=2.4,<3']
 else:
-	install_requires = ['PyJWT>=1,<2','requests>=2,<3']
+	install_requires = ['PyJWT>=1,<2', 'requests>=2.4,<3']
 
 setup(
 	name='pubcontrol',

--- a/src/pubsubmonitor.py
+++ b/src/pubsubmonitor.py
@@ -13,11 +13,9 @@ import urllib
 import time
 import socket
 import logging
-import pkg_resources
 from base64 import b64decode
 from ssl import SSLError
 from .utilities import _gen_auth_jwt_header, _ensure_unicode
-from distutils.version import StrictVersion
 from requests.exceptions import ConnectionError
 
 logger = logging.getLogger(__name__)
@@ -91,9 +89,6 @@ class PubSubMonitor(object):
 				try:
 					logger.debug('stream get %s' % self._stream_uri)
 					timeout = (5,60)
-					if (StrictVersion(pkg_resources.get_distribution('requests').version) <=
-							StrictVersion('2.3')):
-						timeout = 60
 					headers = {}
 					headers['Authorization'] = _gen_auth_jwt_header(
 							self._auth_jwt_claim, self._auth_jwt_key)


### PR DESCRIPTION
This removes support for requests<=2.3. Version 2.4 was released in 2014 so by now it's safe to assume no one is still using older versions. The reason for this PR was that I wanted to remove the import of `pkg_resources` which is very slow (mostly a pain in tests).