### PR TITLE
Use 'collections.abc' instead of deprecated 'collections'

### DIFF
--- a/src/utilities.py
+++ b/src/utilities.py
@@ -6,7 +6,6 @@
 #    :license: MIT, see LICENSE for more details.
 
 import sys
-import collections.abc
 import jwt
 import calendar
 import copy
@@ -23,6 +22,11 @@ except ImportError:
 	tnetstring = None
 
 is_python3 = sys.version_info >= (3,)
+
+if is_python3:
+	import collections.abc as collections
+else:
+	import collections
 
 # An internal method to verify that the zmq and tnetstring packages are
 # available. If not an exception is raised.
@@ -44,9 +48,9 @@ def _ensure_utf8(value):
 			return value.encode('utf-8')
 		elif isinstance(value, str):
 			return value
-	if isinstance(value, collections.abc.Mapping):
+	if isinstance(value, collections.Mapping):
 		return dict(map(_ensure_utf8, value.items()))
-	elif isinstance(value, collections.abc.Iterable):
+	elif isinstance(value, collections.Iterable):
 		return type(value)(map(_ensure_utf8, value))
 	return value
 
@@ -64,9 +68,9 @@ def _ensure_unicode(value):
 			return value.decode('utf-8')
 		elif isinstance(value, unicode):
 			return value
-	if isinstance(value, collections.abc.Mapping):
+	if isinstance(value, collections.Mapping):
 		return dict(map(_ensure_unicode, value.items()))
-	elif isinstance(value, collections.abc.Iterable):
+	elif isinstance(value, collections.Iterable):
 		return type(value)(map(_ensure_unicode, value))
 	return value
 

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -6,7 +6,7 @@
 #    :license: MIT, see LICENSE for more details.
 
 import sys
-import collections
+import collections.abc
 import jwt
 import calendar
 import copy
@@ -44,9 +44,9 @@ def _ensure_utf8(value):
 			return value.encode('utf-8')
 		elif isinstance(value, str):
 			return value
-	if isinstance(value, collections.Mapping):
+	if isinstance(value, collections.abc.Mapping):
 		return dict(map(_ensure_utf8, value.items()))
-	elif isinstance(value, collections.Iterable):
+	elif isinstance(value, collections.abc.Iterable):
 		return type(value)(map(_ensure_utf8, value))
 	return value
 
@@ -64,9 +64,9 @@ def _ensure_unicode(value):
 			return value.decode('utf-8')
 		elif isinstance(value, unicode):
 			return value
-	if isinstance(value, collections.Mapping):
+	if isinstance(value, collections.abc.Mapping):
 		return dict(map(_ensure_unicode, value.items()))
-	elif isinstance(value, collections.Iterable):
+	elif isinstance(value, collections.abc.Iterable):
 		return type(value)(map(_ensure_unicode, value))
 	return value
 


### PR DESCRIPTION
https://docs.python.org/3.9/whatsnew/3.9.html#you-should-check-for-deprecationwarning-in-your-code
> Aliases to Abstract Base Classes in the collections module, like collections.Mapping alias to collections.abc.Mapping, are kept for one last release for backward compatibility. They will be removed from Python 3.10.